### PR TITLE
Remove the redundant `maven-resources-plugin` declaration

### DIFF
--- a/vmvt-cli/pom.xml
+++ b/vmvt-cli/pom.xml
@@ -56,35 +56,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Specify the resources which need to be made accessible to the user -->
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>copy-resources</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/resources</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>src/resources</directory>
-                                    <!--Use filtering so that maven will replace placeholders with values
-                                       from the pom e.g. ${project.version} -->
-                                    <filtering>true</filtering>
-                                    <includes>
-                                        <include>application.properties</include>
-                                        <include>log4j2.xml</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Hi @pnrobinson ,
I'd like to point out that specifying the `maven-resource-plugin` on line 60 in `vmvt-cli/pom.xml` is redundant. The default behavior does the same thing without adding complexity and a potential bugs to the `pom.xml`.

Please feel free to merge and delete the branch if you think the suggested changes are appropriate